### PR TITLE
Missing or mangled headers

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -207,6 +207,7 @@ class Key
         } else {
             // OpenSSL libraries don't have detection methods, so try..catch
             try {
+                // TODO: Silence openssl warning on unrecognised data
                 openssl_x509_export($object, $null);
 
                 return true;

--- a/src/SignatureException.php
+++ b/src/SignatureException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HttpSignatures;
+
+class SignatureException extends Exception
+{
+}

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -75,7 +75,7 @@ class Verification
                     $this->providedSignature()
                     );
                   if (!$result) {
-                      throw new \HttpSignatures\SignatureException('Invalid signature', 1);
+                      throw new SignatureException('Invalid signature', 1);
                   } else {
                       return true;
                   }
@@ -96,12 +96,12 @@ class Verification
                 default:
                     throw new Exception("Unknown key type '".$key->getType()."', cannot verify");
             }
-        } catch (SignatureParseException $e) {
-            return false;
+            // } catch (SignatureParseException $e) {
+        //     return false;
         } catch (KeyStoreException $e) {
             return false;
-        } catch (SignedHeaderNotPresentException $e) {
-            return false;
+            // } catch (SignedHeaderNotPresentException $e) {
+        //     return false;
         }
     }
 

--- a/src/Verification.php
+++ b/src/Verification.php
@@ -70,10 +70,16 @@ class Verification
             $key = $this->key();
             switch ($key->getType()) {
                 case 'secret':
-                  return hash_equals(
+                  $result = hash_equals(
                     $this->expectedSignature()->string(),
                     $this->providedSignature()
                     );
+                  if (!$result) {
+                      throw new \HttpSignatures\SignatureException('Invalid signature', 1);
+                  } else {
+                      return true;
+                  }
+                  // no break
                 case 'asymmetric':
                     $signedString = new SigningString(
                         $this->headerList(),

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -53,6 +53,11 @@ class Verifier
 
                   return false;
                   break;
+                case 'HttpSignatures\SignedHeaderNotPresentException':
+                  $this->status[] = $e->getMessage();
+
+                  return false;
+                  break;
                 default:
                   $this->status[] = 'Unknown exception '.get_class($e).': '.$e->getMessage();
                   throw $e;

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -10,11 +10,17 @@ class Verifier
     private $keyStore;
 
     /**
+     * @var string
+     */
+    private $status;
+
+    /**
      * @param KeyStoreInterface $keyStore
      */
     public function __construct(KeyStoreInterface $keyStore)
     {
         $this->keyStore = $keyStore;
+        $this->status = [];
     }
 
     /**
@@ -26,10 +32,32 @@ class Verifier
     {
         try {
             $verification = new Verification($message, $this->keyStore, 'Signature');
+            $result = $verification->verify();
 
-            return $verification->verify();
-        } catch (\HttpSignatures\HeaderException | \HttpSignatures\SignatureParseException $e) {
-            return false;
+            return $result;
+        } catch (Exception $e) {
+            // TODO: Match at least one header
+            switch (get_class($e)) {
+                case 'HttpSignatures\HeaderException':
+                  $this->status[] = 'Signature header not found';
+
+                  return false;
+                  break;
+                case 'HttpSignatures\SignatureParseException':
+                  $this->status[] = 'Signature header malformed';
+
+                  return false;
+                  break;
+                case 'HttpSignatures\SignatureException':
+                  $this->status[] = $e->getMessage();
+
+                  return false;
+                  break;
+                default:
+                  $this->status[] = 'Unknown exception '.get_class($e).': '.$e->getMessage();
+                  throw $e;
+                  break;
+                }
         }
     }
 
@@ -42,10 +70,27 @@ class Verifier
     {
         try {
             $verification = new Verification($message, $this->keyStore, 'Authorization');
+            $result = $verification->verify();
 
-            return $verification->verify();
-        } catch (\HttpSignatures\HeaderException | HttpSignatures\SignatureParseException $e) {
-            return false;
+            return $result;
+        } catch (Exception $e) {
+            // TODO: Match at least one header
+            switch (get_class($e)) {
+                case 'HttpSignatures\HeaderException':
+                  $this->status[] = 'Authorization header not found';
+
+                  return false;
+                  break;
+                case 'HttpSignatures\SignatureParseException':
+                  $this->status[] = 'Authorization header malformed';
+
+                  return false;
+                  break;
+                default:
+                  $this->status[] = 'Unknown exception '.get_class($e).': '.$e->getMessage();
+                  throw $e;
+                  break;
+                }
         }
     }
 
@@ -56,9 +101,25 @@ class Verifier
      */
     public function isValidDigest($message)
     {
-        $bodyDigest = BodyDigest::fromMessage($message);
+        if (0 == sizeof($message->getHeader('Digest'))) {
+            $this->status[] = 'Digest header mising';
 
-        return $bodyDigest->isValid($message);
+            return false;
+        }
+        try {
+            $bodyDigest = BodyDigest::fromMessage($message);
+        } catch (\HttpSignatures\DigestException $e) {
+            $this->status[] = $e->getMessage();
+
+            return false;
+        }
+
+        $isValidDigest = $bodyDigest->isValid($message);
+        if (!$isValidDigest) {
+            $this->status[] = 'Digest header invalid';
+        }
+
+        return $isValidDigest;
     }
 
     /**
@@ -96,5 +157,10 @@ class Verifier
     public function keyStore()
     {
         return $this->keyStore;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
     }
 }

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -28,7 +28,7 @@ class Verifier
             $verification = new Verification($message, $this->keyStore, 'Signature');
 
             return $verification->verify();
-        } catch (\HttpSignatures\HeaderException $e) {
+        } catch (\HttpSignatures\HeaderException | \HttpSignatures\SignatureParseException $e) {
             return false;
         }
     }
@@ -40,9 +40,13 @@ class Verifier
      */
     public function isAuthorized($message)
     {
-        $verification = new Verification($message, $this->keyStore, 'Authorization');
+        try {
+            $verification = new Verification($message, $this->keyStore, 'Authorization');
 
-        return $verification->verify();
+            return $verification->verify();
+        } catch (\HttpSignatures\HeaderException | HttpSignatures\SignatureParseException $e) {
+            return false;
+        }
     }
 
     /**

--- a/tests/KeyStoreRsaTest.php
+++ b/tests/KeyStoreRsaTest.php
@@ -4,7 +4,6 @@ namespace HttpSignatures\tests;
 
 use HttpSignatures\KeyStore;
 use HttpSignatures\Key;
-use HttpSignatures\KeyException;
 use HttpSignatures\Tests\TestKeys;
 use PHPUnit\Framework\TestCase;
 
@@ -108,7 +107,7 @@ class KeyStoreRsaTest extends TestCase
           'private_key_type' => 'OPENSSL_KEYTYPE_RSA',
           'private_key_bits' => 1024, ]
         );
-        $this->expectException(KeyException::class);
+        $this->expectException(\HTTPSignatures\KeyException::class);
         $ks = new Key('badpki', [TestKeys::rsaCert, $privateKey]);
     }
 }

--- a/tests/NewReferenceTest.php
+++ b/tests/NewReferenceTest.php
@@ -189,6 +189,18 @@ content-length: 18';
                 'Signature', self::defaultTestSignatureLineValue
             ))
         );
+
+        // Authorized <> Signed
+        $this->assertFalse(
+            $this->verifier->isSigned($this->referenceMessage->withHeader(
+                'Authorization', self::defaultTestAuthorizationHeaderValue
+            ))
+        );
+        $this->assertFalse(
+            $this->verifier->isAuthorized($this->referenceMessage->withHeader(
+                'Signature', self::defaultTestSignatureLineValue
+            ))
+        );
     }
 
     /**

--- a/tests/RsaContextTest.php
+++ b/tests/RsaContextTest.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Psr7\Request;
 use HttpSignatures\Context;
 use HttpSignatures\Tests\TestKeys;
 use PHPUnit\Framework\TestCase;
-use HttpSignatures\AlgorithmException;
 
 class RsaContextTest extends TestCase
 {
@@ -89,7 +88,7 @@ class RsaContextTest extends TestCase
 
     public function testRsaBadalgorithm()
     {
-        $this->expectException(AlgorithmException::class);
+        $this->expectException(\HTTPSignatures\AlgorithmException::class);
         $sha224context = new Context([
               'keys' => ['rsa1' => TestKeys::rsaPrivateKey],
               'algorithm' => 'rsa-sha224',

--- a/tests/SignatureParametersParserTest.php
+++ b/tests/SignatureParametersParserTest.php
@@ -3,7 +3,6 @@
 namespace HttpSignatures\tests;
 
 use HttpSignatures\SignatureParametersParser;
-use HttpSignatures\SignatureParseException;
 use PHPUnit\Framework\TestCase;
 
 class SignatureParametersParserTest extends TestCase
@@ -27,7 +26,7 @@ class SignatureParametersParserTest extends TestCase
     public function testParseThrowsTypedException()
     {
         $parser = new SignatureParametersParser('nope');
-        $this->expectException(SignatureParseException::class);
+        $this->expectException(\HTTPSignatures\SignatureParseException::class);
         $parser->parse();
     }
 
@@ -37,7 +36,7 @@ class SignatureParametersParserTest extends TestCase
         $parser = new SignatureParametersParser(
             'keyId="example",algorithm="hmac-sha1",headers="(request-target) date"'
         );
-        $this->expectException(SignatureParseException::class);
+        $this->expectException(\HTTPSignatures\SignatureParseException::class);
         $parser->parse();
     }
 }

--- a/tests/VerifierHmacTest.php
+++ b/tests/VerifierHmacTest.php
@@ -130,37 +130,36 @@ class VerifierHmacTest extends TestCase
         ));
     }
 
-    public function testRejectBadDigestName()
+    public function testRejectBadDigestAlgorithm()
     {
         $message = $this->signedMessage->withoutHeader('Digest')
           ->withHeader('Digest', 'SHA-255=xxx');
-        $this->expectException(DigestException::class);
         $this->assertFalse($this->verifier->isValidDigest($message));
+        $this->assertEquals(
+          "'SHA-255' in Digest header is not a valid algorithm",
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectBadDigestLine()
     {
         $message = $this->signedMessage->withoutHeader('Digest')
           ->withHeader('Digest', 'h7gWacNDycTMI1vWH4Z3f3Wek1nNZS8px82bBQEEARI=');
-        $this->expectException(DigestException::class);
         $this->assertFalse($this->verifier->isValidDigest($message));
+        $this->assertEquals(
+          "'h7gWacNDycTMI1vWH4Z3f3Wek1nNZS8px82bBQEEARI' in Digest header is not a valid algorithm",
+          $this->verifier->getStatus()[0]
+        );
     }
 
-    // TODO: Handle no 'headers' parameter
-    // public function testVerifyMessagesNoHeaders()
-    // {
-    //     $this->assertTrue($this->verifier->isSigned($this->signedMessageNoHeaders));
-    //     $this->assertTrue($this->verifier->isAuthorized($this->authorizedMessageNoHeaders));
-    // }
+    public function testVerifyMessagesNoHeaders()
+    {
+        $this->assertTrue($this->verifier->isSigned($this->signedMessageNoHeaders));
+        $this->assertTrue($this->verifier->isAuthorized($this->authorizedMessageNoHeaders));
+    }
 
     public function testVerifyAuthorized()
     {
-        // $message = $this->validMessage->withHeader(
-        //   'Authorization',
-        //   'Signature '.$this->validMessage->getHeader('Signature')[0]
-        //   );
-        // $message = $message->withoutHeader('Signature');
-
         $this->assertTrue($this->verifier->isAuthorized($this->authorizedMessage));
     }
 
@@ -196,14 +195,12 @@ class VerifierHmacTest extends TestCase
     public function testRejectHmacMessageWithGarbageSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'not="a",valid="signature"');
-        // $this->expectException("HttpSignatures\SignatureParseException");
         $this->assertFalse($this->verifier->isSigned($message));
     }
 
     public function testRejectHmacMessageWithPartialSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"');
-        // $this->expectException("HttpSignatures\SignatureParseException");
         $this->assertFalse($this->verifier->isSigned($message));
     }
 

--- a/tests/VerifierHmacTest.php
+++ b/tests/VerifierHmacTest.php
@@ -5,7 +5,6 @@ namespace HttpSignatures\tests;
 use GuzzleHttp\Psr7\Request;
 use HttpSignatures\KeyStore;
 use HttpSignatures\Verifier;
-use HttpSignatures\DigestException;
 use PHPUnit\Framework\TestCase;
 
 class VerifierHmacTest extends TestCase

--- a/tests/VerifierHmacTest.php
+++ b/tests/VerifierHmacTest.php
@@ -196,15 +196,15 @@ class VerifierHmacTest extends TestCase
     public function testRejectHmacMessageWithGarbageSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'not="a",valid="signature"');
-        $this->expectException("HttpSignatures\SignatureParseException");
-        $this->verifier->isSigned($message);
+        // $this->expectException("HttpSignatures\SignatureParseException");
+        $this->assertFalse($this->verifier->isSigned($message));
     }
 
     public function testRejectHmacMessageWithPartialSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"');
-        $this->expectException("HttpSignatures\SignatureParseException");
-        $this->verifier->isSigned($message);
+        // $this->expectException("HttpSignatures\SignatureParseException");
+        $this->assertFalse($this->verifier->isSigned($message));
     }
 
     public function testRejectsHmacMessageWithUnknownKeyId()

--- a/tests/VerifierRsaTest.php
+++ b/tests/VerifierRsaTest.php
@@ -137,23 +137,27 @@ class VerifierRsaTest extends TestCase
 
     public function testRejectRsaMessageWithGarbageSignatureHeader()
     {
-        $this->expectException("HttpSignatures\SignatureParseException");
+        // $this->expectException("HttpSignatures\SignatureParseException");
         // $this->verifier->isSigned(
         //   $this->sha1SignedMessage->withHeader('Signature', 'not="a",valid="signature"')
         // );
-        $this->verifier->isSigned(
-          $this->sha256SignedMessage->withHeader('Signature', 'not="a",valid="signature"')
+        $this->assertFalse(
+          $this->verifier->isSigned(
+            $this->sha256SignedMessage->withHeader('Signature', 'not="a",valid="signature"')
+          )
         );
     }
 
     public function testRejectRsaMessageWithPartialSignatureHeader()
     {
-        $this->expectException("HttpSignatures\SignatureParseException");
+        // $this->expectException("HttpSignatures\SignatureParseException");
         // $this->verifier->isSigned(
         //   $this->sha1SignedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"')
         // );
-        $this->verifier->isSigned(
-          $this->sha256SignedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"')
+        $this->assertFalse(
+          $this->verifier->isSigned(
+            $this->sha256SignedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"')
+          )
         );
     }
 

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -226,5 +226,9 @@ class VerifierTest extends TestCase
     {
         $message = $this->signedMessage->withoutHeader('Date');
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          "Header 'date' not in message",
+          $this->verifier->getStatus()[0]
+        );
     }
 }

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -135,6 +135,10 @@ class VerifierTest extends TestCase
         $this->assertFalse(
           $this->verifier->isAuthorized($this->signedMessage)
         );
+        $this->assertEquals(
+          'Authorization header not found',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectOnlyAuthorizationHeaderAsSigned()
@@ -142,18 +146,30 @@ class VerifierTest extends TestCase
         $this->assertFalse(
         $this->verifier->isSigned($this->authorizedMessage)
       );
+        $this->assertEquals(
+        'Signature header malformed',
+        $this->verifier->getStatus()[0]
+      );
     }
 
     public function testRejectTamperedRequestMethod()
     {
         $message = $this->signedMessage->withMethod('POST');
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          'Invalid signature',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectTamperedDate()
     {
         $message = $this->signedMessage->withHeader('Date', self::DATE_DIFFERENT);
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          'Invalid signature',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectTamperedSignature()
@@ -163,26 +179,40 @@ class VerifierTest extends TestCase
             preg_replace('/signature="/', 'signature="x', $this->signedMessage->getHeader('Signature')[0])
         );
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          'Invalid signature',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectMessageWithoutSignatureHeader()
     {
         $message = $this->signedMessage->withoutHeader('Signature');
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          'Signature header not found',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectMessageWithGarbageSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'not="a",valid="signature"');
-        // $this->expectException("HttpSignatures\SignatureParseException");
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          'Signature header malformed',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectMessageWithPartialSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"');
-        // $this->expectException("HttpSignatures\SignatureParseException");
         $this->assertFalse($this->verifier->isSigned($message));
+        $this->assertEquals(
+          'Signature header malformed',
+          $this->verifier->getStatus()[0]
+        );
     }
 
     public function testRejectsMessageWithUnknownKeyId()

--- a/tests/VerifierTest.php
+++ b/tests/VerifierTest.php
@@ -132,14 +132,16 @@ class VerifierTest extends TestCase
 
     public function testRejectOnlySignatureHeaderAsAuthorized()
     {
-        $this->expectException("HttpSignatures\HeaderException");
-        $this->verifier->isAuthorized($this->signedMessage);
+        $this->assertFalse(
+          $this->verifier->isAuthorized($this->signedMessage)
+        );
     }
 
     public function testRejectOnlyAuthorizationHeaderAsSigned()
     {
-        $this->expectException("HttpSignatures\SignatureParseException");
-        $this->verifier->isSigned($this->authorizedMessage);
+        $this->assertFalse(
+        $this->verifier->isSigned($this->authorizedMessage)
+      );
     }
 
     public function testRejectTamperedRequestMethod()
@@ -172,15 +174,15 @@ class VerifierTest extends TestCase
     public function testRejectMessageWithGarbageSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'not="a",valid="signature"');
-        $this->expectException("HttpSignatures\SignatureParseException");
-        $this->verifier->isSigned($message);
+        // $this->expectException("HttpSignatures\SignatureParseException");
+        $this->assertFalse($this->verifier->isSigned($message));
     }
 
     public function testRejectMessageWithPartialSignatureHeader()
     {
         $message = $this->signedMessage->withHeader('Signature', 'keyId="aa",algorithm="bb"');
-        $this->expectException("HttpSignatures\SignatureParseException");
-        $this->verifier->isSigned($message);
+        // $this->expectException("HttpSignatures\SignatureParseException");
+        $this->assertFalse($this->verifier->isSigned($message));
     }
 
     public function testRejectsMessageWithUnknownKeyId()


### PR DESCRIPTION
Instead of an exception, simply fail validation if the signed or authorized header is mangled or missing. Add getStatus() for verifier to retrieve status of failures.