### PR TITLE
V11 signing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2",
         "guzzlehttp/psr7": "^1.2",
-        "phpunit/phpunit": "~5.6",
+        "phpunit/phpunit": "^5.7",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/psr-http-message-bridge": "^1.0.2",
         "zendframework/zend-diactoros": "^1.1",

--- a/phpunit
+++ b/phpunit
@@ -1,3 +1,5 @@
 #!/bin/bash
-echo "vendor/bin/phpunit $* && vendor/bin/php-cs-fixer fix -v --dry-run"
-vendor/bin/phpunit $* && vendor/bin/php-cs-fixer fix -v --dry-run
+vendor/bin/phpunit $*
+if [ $? -eq 0 ]; then
+  ./vendor/bin/php-cs-fixer fix -v --dry-run || echo 'vendor/bin/php-cs-fixer fix -v'
+  fi

--- a/src/Context.php
+++ b/src/Context.php
@@ -17,13 +17,16 @@ class Context
     private $signingKeyId;
 
     /** @var string */
-    private $hashAlgorithm;
-
-    /** @var string */
     private $defaultCreated = 'now';
 
     /** @var string */
     private $defaultExpires = 'none';
+
+    /** @var string */
+    private $signatureAlgorithm;
+
+    /** @var string */
+    private $hashAlgorithm;
 
     /**
      * @param array $args
@@ -199,9 +202,10 @@ class Context
 
     public function setAlgorithm($name)
     {
-        if (empty($algorithm) || $name == '') {
+        if (empty($name)) {
             $name = 'hs2019';
         }
+
         $algorithm = explode('-', $name);
         if (in_array($name, $this->newAlgorithmNames)) {
             $this->hashAlgorithm = $name;

--- a/src/Context.php
+++ b/src/Context.php
@@ -49,10 +49,10 @@ class Context
         }
 
         // TODO: Read headers as minimum for verification
-        // TODO: Function to set headers after creation
         // headers list for signing; not necessary for verifying.
         if (isset($args['headers'])) {
-            $this->headers = $args['headers'];
+            $this->setHeaders($args['headers']);
+            // $this->headers = $args['headers'];
         }
 
         // signingKeyId specifies the key used for signing messages.
@@ -278,7 +278,9 @@ class Context
 
     public function setHeaders($headers)
     {
-        if (is_array($headers)) {
+        if (empty($headers)) {
+            $this->headers = [];
+        } elseif (is_array($headers)) {
             $this->headers = $headers;
         } else {
             $this->headers = explode(' ', $headers);

--- a/src/Context.php
+++ b/src/Context.php
@@ -21,7 +21,7 @@ class Context
      *
      * @throws Exception
      */
-    public function __construct($args)
+    public function __construct($args = [])
     {
         if (isset($args['keys']) && isset($args['keyStore'])) {
             throw new Exception(__CLASS__.' accepts keys or keyStore but not both');

--- a/src/Context.php
+++ b/src/Context.php
@@ -254,15 +254,24 @@ class Context
 
     public function setExpires($expires)
     {
-        $this->defaultexpires = $expires;
+        $this->defaultExpires = $expires;
     }
 
     public function signatureDates()
     {
         $signatureDates = new SignatureDates();
         $signatureDates->setCreated(SignatureDates::Offset($this->defaultCreated));
-        $signatureDates->setExpires(SignatureDates::Offset($this->defaultExpires));
+        $signatureDates->setExpires(SignatureDates::Offset($this->defaultExpires, $signatureDates->getCreated()));
 
         return $signatureDates;
+    }
+
+    public function setHeaders($headers)
+    {
+        if (is_array($headers)) {
+            $this->headers = $headers;
+        } else {
+            $this->headers = explode(' ', $headers);
+        }
     }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -199,6 +199,9 @@ class Context
 
     public function setAlgorithm($name)
     {
+        if (empty($algorithm) || $name == '') {
+            $name = 'hs2019';
+        }
         $algorithm = explode('-', $name);
         if (in_array($name, $this->newAlgorithmNames)) {
             $this->hashAlgorithm = $name;
@@ -291,11 +294,11 @@ class Context
         } else {
             $newHeaders = explode(' ', $headers);
         }
-        if (in_array($this->hashAlgorithm, $this->newAlgorithmNames)) {
-            if (!is_null($newHeaders) && sizeof($newHeaders) > 0 && !in_array('(created)', $newHeaders)) {
-                throw new HeaderException("Required Signature header '(created)' not included", 1);
-            }
-        }
+        // if (in_array($this->hashAlgorithm, $this->newAlgorithmNames)) {
+        //     if (!is_null($newHeaders) && sizeof($newHeaders) > 0 && !in_array('(created)', $newHeaders)) {
+        //         throw new HeaderException("Required Signature header '(created)' not included", 1);
+        //     }
+        // }
         $this->headers = $newHeaders;
     }
 }

--- a/src/ContextException.php
+++ b/src/ContextException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HttpSignatures;
+
+class ContextException extends \Exception
+{
+}

--- a/src/DsaAlgorithm.php
+++ b/src/DsaAlgorithm.php
@@ -12,7 +12,11 @@ class DsaAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        $this->digestName = $digestName;
+      if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+          $this->digestName = $digestName;
+      } else {
+          throw new AlgorithmException($digestName.' is not a supported hash format');
+      }
     }
 
     /**
@@ -53,12 +57,16 @@ class DsaAlgorithm implements AlgorithmInterface
     private function getRsaHashAlgo($digestName)
     {
         switch ($digestName) {
+        case 'sha512':
+            return OPENSSL_ALGO_SHA512;
+        case 'sha384':
+            return OPENSSL_ALGO_SHA384;
         case 'sha256':
             return OPENSSL_ALGO_SHA256;
         case 'sha1':
             return OPENSSL_ALGO_SHA1;
         default:
-            throw new HttpSignatures\AlgorithmException($digestName.' is not a supported hash format');
+            throw new AlgorithmException($digestName.' is not a supported hash format');
       }
     }
 }

--- a/src/DsaAlgorithm.php
+++ b/src/DsaAlgorithm.php
@@ -12,7 +12,7 @@ class DsaAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512', 'hs2019'])) {
             $this->digestName = $digestName;
         } else {
             throw new AlgorithmException($digestName.' is not a supported hash format');
@@ -24,7 +24,11 @@ class DsaAlgorithm implements AlgorithmInterface
      */
     public function name()
     {
-        return sprintf('dsa-%s', $this->digestName);
+        if (in_array($this->digestName, ['hs2019'])) {
+            return $this->digestName;
+        } else {
+            return 'dsa-'.$this->digestName;
+        }
     }
 
     /**
@@ -57,6 +61,7 @@ class DsaAlgorithm implements AlgorithmInterface
     private function getRsaHashAlgo($digestName)
     {
         switch ($digestName) {
+        case 'hs2019':
         case 'sha512':
             return OPENSSL_ALGO_SHA512;
         case 'sha384':

--- a/src/DsaAlgorithm.php
+++ b/src/DsaAlgorithm.php
@@ -12,11 +12,11 @@ class DsaAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-      if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
-          $this->digestName = $digestName;
-      } else {
-          throw new AlgorithmException($digestName.' is not a supported hash format');
-      }
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+            $this->digestName = $digestName;
+        } else {
+            throw new AlgorithmException($digestName.' is not a supported hash format');
+        }
     }
 
     /**

--- a/src/EcAlgorithm.php
+++ b/src/EcAlgorithm.php
@@ -12,7 +12,11 @@ class EcAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        $this->digestName = $digestName;
+      if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+          $this->digestName = $digestName;
+      } else {
+          throw new AlgorithmException($digestName.' is not a supported hash format');
+      }
     }
 
     /**
@@ -53,6 +57,10 @@ class EcAlgorithm implements AlgorithmInterface
     private function getEcHashAlgo($digestName)
     {
         switch ($digestName) {
+        case 'sha512':
+            return OPENSSL_ALGO_SHA512;
+        case 'sha384':
+            return OPENSSL_ALGO_SHA384;
         case 'sha256':
             return OPENSSL_ALGO_SHA256;
         case 'sha1':

--- a/src/EcAlgorithm.php
+++ b/src/EcAlgorithm.php
@@ -12,11 +12,11 @@ class EcAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-      if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
-          $this->digestName = $digestName;
-      } else {
-          throw new AlgorithmException($digestName.' is not a supported hash format');
-      }
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+            $this->digestName = $digestName;
+        } else {
+            throw new AlgorithmException($digestName.' is not a supported hash format');
+        }
     }
 
     /**

--- a/src/EcAlgorithm.php
+++ b/src/EcAlgorithm.php
@@ -12,7 +12,7 @@ class EcAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512', 'hs2019'])) {
             $this->digestName = $digestName;
         } else {
             throw new AlgorithmException($digestName.' is not a supported hash format');
@@ -24,7 +24,11 @@ class EcAlgorithm implements AlgorithmInterface
      */
     public function name()
     {
-        return sprintf('ec-%s', $this->digestName);
+        if (in_array($this->digestName, ['hs2019'])) {
+            return $this->digestName;
+        } else {
+            return 'ec-'.$this->digestName;
+        }
     }
 
     /**
@@ -57,6 +61,7 @@ class EcAlgorithm implements AlgorithmInterface
     private function getEcHashAlgo($digestName)
     {
         switch ($digestName) {
+        case 'hs2019':
         case 'sha512':
             return OPENSSL_ALGO_SHA512;
         case 'sha384':

--- a/src/HeaderList.php
+++ b/src/HeaderList.php
@@ -63,7 +63,7 @@ class HeaderList
         return strtolower($name);
     }
 
-    public function list()
+    public function listHeaders()
     {
         return $this->names;
     }

--- a/src/HeaderList.php
+++ b/src/HeaderList.php
@@ -15,14 +15,13 @@ class HeaderList
      */
     public function __construct(array $names, $headerListSpecified = true)
     {
+        $this->names = [];
         if (!$names) {
-            $names = ['date'];
             $this->headerListSpecified = false;
         } else {
-            $this->names = array_map(
-              [$this, 'normalize'],
-              $names
-          );
+            foreach ($names as $name) {
+                $this->names[] = strtolower($name);
+            }
             $this->headerListSpecified = $headerListSpecified;
         }
     }
@@ -42,7 +41,11 @@ class HeaderList
      */
     public function string()
     {
-        return implode(' ', $this->names);
+        if (sizeof($this->names)) {
+            return implode(' ', $this->names);
+        } else {
+            return '';
+        }
     }
 
     /**

--- a/src/HeaderList.php
+++ b/src/HeaderList.php
@@ -62,4 +62,9 @@ class HeaderList
     {
         return strtolower($name);
     }
+
+    public function list()
+    {
+        return $this->names;
+    }
 }

--- a/src/HmacAlgorithm.php
+++ b/src/HmacAlgorithm.php
@@ -12,7 +12,11 @@ class HmacAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        $this->digestName = $digestName;
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+            $this->digestName = $digestName;
+        } else {
+            throw new AlgorithmException($digestName.' is not a supported hash format');
+        }
     }
 
     /**

--- a/src/HmacAlgorithm.php
+++ b/src/HmacAlgorithm.php
@@ -12,7 +12,7 @@ class HmacAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512', 'hs2019'])) {
             $this->digestName = $digestName;
         } else {
             throw new AlgorithmException($digestName.' is not a supported hash format');
@@ -24,7 +24,11 @@ class HmacAlgorithm implements AlgorithmInterface
      */
     public function name()
     {
-        return sprintf('hmac-%s', $this->digestName);
+        if (in_array($this->digestName, ['hs2019'])) {
+            return $this->digestName;
+        } else {
+            return 'hmac-'.$this->digestName;
+        }
     }
 
     /**

--- a/src/HmacAlgorithm.php
+++ b/src/HmacAlgorithm.php
@@ -39,6 +39,25 @@ class HmacAlgorithm implements AlgorithmInterface
      */
     public function sign($secret, $data)
     {
-        return hash_hmac($this->digestName, $data, $secret, true);
+        switch ($this->digestName) {
+          case 'hs2019':
+          case 'sha512':
+            $digest = 'sha512';
+            break;
+          case 'sha384':
+            $digest = 'sha384';
+            break;
+          case 'sha256':
+            $digest = 'sha256';
+            break;
+          case 'sha1':
+            $digest = 'sha1';
+            break;
+          default:
+            throw new AlgorithmException($digestName.' is not a supported hash format');
+            break;
+        }
+
+        return hash_hmac($digest, $data, $secret, true);
     }
 }

--- a/src/KeyStore.php
+++ b/src/KeyStore.php
@@ -10,11 +10,13 @@ class KeyStore implements KeyStoreInterface
     /**
      * @param array $keys
      */
-    public function __construct($keys)
+    public function __construct($keys = [])
     {
         $this->keys = [];
-        foreach ($keys as $id => $key) {
-            $this->keys[$id] = new Key($id, $key);
+        if (!empty($keys)) {
+            foreach ($keys as $id => $key) {
+                $this->keys[$id] = new Key($id, $key);
+            }
         }
     }
 
@@ -25,8 +27,11 @@ class KeyStore implements KeyStoreInterface
      *
      * @throws KeyStoreException
      */
-    public function fetch($keyId)
+    public function fetch($keyId = null)
     {
+        if (empty($keyId) && 1 == sizeof($this->keys)) {
+            return reset($this->keys);
+        }
         if (isset($this->keys[$keyId])) {
             return $this->keys[$keyId];
         } else {

--- a/src/KeyStore.php
+++ b/src/KeyStore.php
@@ -33,4 +33,24 @@ class KeyStore implements KeyStoreInterface
             throw new KeyStoreException("Key '$keyId' not found");
         }
     }
+
+    public function count()
+    {
+        return sizeof($this->keys);
+    }
+
+    public function addKeys($keys)
+    {
+        $newKeys = [];
+        foreach ($keys as $id => $key) {
+            if (isset($this->keys[$id])) {
+                throw new KeyStoreException(
+                "keyId '$id' already in Key Store", 1
+              );
+            } else {
+                $newKeys[$id] = new Key($id, $key);
+            }
+        }
+        $this->keys = array_merge($newKeys, $this->keys);
+    }
 }

--- a/src/RsaAlgorithm.php
+++ b/src/RsaAlgorithm.php
@@ -12,11 +12,11 @@ class RsaAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-      if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
-          $this->digestName = $digestName;
-      } else {
-          throw new AlgorithmException($digestName.' is not a supported hash format');
-      }
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+            $this->digestName = $digestName;
+        } else {
+            throw new AlgorithmException($digestName.' is not a supported hash format');
+        }
     }
 
     /**

--- a/src/RsaAlgorithm.php
+++ b/src/RsaAlgorithm.php
@@ -12,7 +12,7 @@ class RsaAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+        if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512', 'hs2019'])) {
             $this->digestName = $digestName;
         } else {
             throw new AlgorithmException($digestName.' is not a supported hash format');
@@ -24,7 +24,11 @@ class RsaAlgorithm implements AlgorithmInterface
      */
     public function name()
     {
-        return sprintf('rsa-%s', $this->digestName);
+        if (in_array($this->digestName, ['hs2019'])) {
+            return $this->digestName;
+        } else {
+            return 'rsa-'.$this->digestName;
+        }
     }
 
     /**
@@ -57,6 +61,7 @@ class RsaAlgorithm implements AlgorithmInterface
     private function getRsaHashAlgo($digestName)
     {
         switch ($digestName) {
+        case 'hs2019':
         case 'sha512':
             return OPENSSL_ALGO_SHA512;
         case 'sha384':

--- a/src/RsaAlgorithm.php
+++ b/src/RsaAlgorithm.php
@@ -12,7 +12,11 @@ class RsaAlgorithm implements AlgorithmInterface
      */
     public function __construct($digestName)
     {
-        $this->digestName = $digestName;
+      if (in_array($digestName, ['sha1', 'sha256', 'sha384', 'sha512'])) {
+          $this->digestName = $digestName;
+      } else {
+          throw new AlgorithmException($digestName.' is not a supported hash format');
+      }
     }
 
     /**
@@ -53,12 +57,16 @@ class RsaAlgorithm implements AlgorithmInterface
     private function getRsaHashAlgo($digestName)
     {
         switch ($digestName) {
+        case 'sha512':
+            return OPENSSL_ALGO_SHA512;
+        case 'sha384':
+            return OPENSSL_ALGO_SHA384;
         case 'sha256':
             return OPENSSL_ALGO_SHA256;
         case 'sha1':
             return OPENSSL_ALGO_SHA1;
         default:
-            throw new HttpSignatures\AlgorithmException($digestName.' is not a supported hash format');
+            throw new AlgorithmException($digestName.' is not a supported hash format');
       }
     }
 }

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -21,11 +21,11 @@ class Signature
      * @param AlgorithmInterface $algorithm
      * @param HeaderList         $headerList
      */
-    public function __construct($message, Key $key, AlgorithmInterface $algorithm, HeaderList $headerList)
+    public function __construct($message, Key $key, AlgorithmInterface $algorithm, HeaderList $headerList, $signatureDates = null)
     {
         $this->key = $key;
         $this->algorithm = $algorithm;
-        $this->signingString = new SigningString($headerList, $message);
+        $this->signingString = new SigningString($headerList, $message, $signatureDates);
     }
 
     public function string()

--- a/src/SignatureDates.php
+++ b/src/SignatureDates.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace HttpSignatures;
+
+class SignatureDates
+{
+    /** @var int */
+    private $created;
+
+    /** @var int */
+    private $expires;
+
+    /** @var int */
+    private $createdDrift = 1;
+
+    /** @var int */
+    private $expiresDrift = 0;
+
+    public function unSetCreated()
+    {
+        $this->created = null;
+    }
+
+    public function unSetExpires()
+    {
+        $this->expires = null;
+    }
+
+    public function hasStarted($atTime = null)
+    {
+        if (empty($atTime)) {
+            $atTime = time();
+        }
+        if (empty($this->created)) {
+            return true;
+        } else {
+            return  $this->created <= ($atTime + $this->createdDrift);
+        }
+    }
+
+    public function hasExpired($atTime = null)
+    {
+        if (empty($atTime)) {
+            $atTime = time();
+        }
+        if (empty($this->expires)) {
+            return false;
+        } else {
+            // return ( $atTime  ($this->expires) );
+            return  $atTime > ($this->expires + $this->expiresDrift);
+        }
+    }
+
+    public function setCreated($time)
+    {
+        $this->created = $time;
+    }
+
+    public function setExpires($time)
+    {
+        $this->expires = $time;
+    }
+
+    public function setCreatedDrift($drift = 0)
+    {
+        $this->createdDrift = $drift;
+    }
+
+    public function setExpiresDrift($drift = 0)
+    {
+        $this->expiresDrift = $drift;
+    }
+
+    public function setDrift($drift = 0)
+    {
+        $this->setCreatedDrift($drift);
+        $this->setExpiredDrift($drift);
+    }
+
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    public function getExpires()
+    {
+        return $this->expires;
+    }
+
+    public function sinceCreated()
+    {
+        if (empty($this->created)) {
+            return null;
+        } else {
+            return  time() - $this->created;
+        }
+    }
+
+    public function toExpire()
+    {
+        if (empty($this->expires)) {
+            return null;
+        } else {
+            return  $this->expires - time();
+        }
+    }
+}

--- a/src/SignatureDates.php
+++ b/src/SignatureDates.php
@@ -105,16 +105,20 @@ class SignatureDates
         }
     }
 
-    public static function Offset($value)
+    public static function Offset($value, $start = null)
     {
         if ('now' == $value) {
             return time();
         } elseif ('none' == $value) {
             return null;
-        } elseif ('+' == substr($value, 0, 1)) {
-            return time() + substr($value, 1);
+        }
+        if (empty($start)) {
+            $start = time();
+        }
+        if ('+' == substr($value, 0, 1)) {
+            return $start + substr($value, 1);
         } elseif ('-' == substr($value, 0, 1)) {
-            return time() - substr($value, 1);
+            return $start - substr($value, 1);
         } else {
             return $value;
         }

--- a/src/SignatureDates.php
+++ b/src/SignatureDates.php
@@ -104,4 +104,19 @@ class SignatureDates
             return  $this->expires - time();
         }
     }
+
+    public static function Offset($value)
+    {
+        if ('now' == $value) {
+            return time();
+        } elseif ('none' == $value) {
+            return null;
+        } elseif ('+' == substr($value, 0, 1)) {
+            return time() + substr($value, 1);
+        } elseif ('-' == substr($value, 0, 1)) {
+            return time() - substr($value, 1);
+        } else {
+            return $value;
+        }
+    }
 }

--- a/src/SignatureDatesException.php
+++ b/src/SignatureDatesException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HttpSignatures;
+
+class SignatureDatesException extends \Exception
+{
+}

--- a/src/SignatureParameters.php
+++ b/src/SignatureParameters.php
@@ -10,12 +10,13 @@ class SignatureParameters
      * @param HeaderList         $headerList
      * @param Signature          $signature
      */
-    public function __construct($key, $algorithm, $headerList, $signature)
+    public function __construct($key, $algorithm, $headerList, $signature, $signatureDates = null)
     {
         $this->key = $key;
         $this->algorithm = $algorithm;
         $this->headerList = $headerList;
         $this->signature = $signature;
+        $this->signatureDates = $signatureDates;
     }
 
     /**
@@ -34,6 +35,26 @@ class SignatureParameters
         $components = [];
         $components[] = sprintf('keyId="%s"', $this->key->getId());
         $components[] = sprintf('algorithm="%s"', $this->algorithm->name());
+        if (in_array($this->algorithm->name(), ['hs2019'])) {
+            if (!empty($this->signatureDates)) {
+                if (in_array(
+                  '(created)',
+                  $this->headerList->list()
+                ) &&
+                  !empty($this->signatureDates->getCreated())
+                ) {
+                    $components[] = sprintf('created=%s', $this->signatureDates->getCreated());
+                }
+                if (in_array(
+                  '(expires)',
+                  $this->headerList->list()
+                ) &&
+                  !empty($this->signatureDates->getExpires())
+                ) {
+                    $components[] = sprintf('expires=%s', $this->signatureDates->getExpires());
+                }
+            }
+        }
         if ($this->headerList->headerListSpecified()) {
             $components[] = sprintf('headers="%s"', $this->headerList->string());
         }

--- a/src/SignatureParameters.php
+++ b/src/SignatureParameters.php
@@ -39,7 +39,7 @@ class SignatureParameters
             if (!empty($this->signatureDates)) {
                 if (in_array(
                   '(created)',
-                  $this->headerList->list()
+                  $this->headerList->listHeaders()
                 ) &&
                   !empty($this->signatureDates->getCreated())
                 ) {
@@ -47,7 +47,7 @@ class SignatureParameters
                 }
                 if (in_array(
                   '(expires)',
-                  $this->headerList->list()
+                  $this->headerList->listHeaders()
                 ) &&
                   !empty($this->signatureDates->getExpires())
                 ) {

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -20,11 +20,12 @@ class Signer
      * @param HmacAlgorithm $algorithm
      * @param HeaderList    $headerList
      */
-    public function __construct($key, $algorithm, $headerList)
+    public function __construct($key, $algorithm, $headerList, $signatureDates = null)
     {
         $this->key = $key;
         $this->algorithm = $algorithm;
         $this->headerList = $headerList;
+        $this->signatureDates = $signatureDates;
     }
 
     /**
@@ -90,7 +91,8 @@ class Signer
             $this->key,
             $this->algorithm,
             $this->headerList,
-            $this->signature($message)
+            $this->signature($message),
+            $this->signatureDates
         );
     }
 
@@ -105,13 +107,14 @@ class Signer
             $message,
             $this->key,
             $this->algorithm,
-            $this->headerList
+            $this->headerList,
+            $this->signatureDates
         );
     }
 
     public function getSigningString($message)
     {
-        $singingString = new SigningString($this->headerList, $message);
+        $singingString = new SigningString($this->headerList, $message, $this->signatureDates);
 
         return $singingString->string();
     }

--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -16,6 +16,7 @@ class SigningString
     private $signatureDates;
 
     // TODO: Make signatureDates mandatory
+
     /**
      * @param HeaderList       $headerList
      * @param RequestInterface $message

--- a/src/SigningString.php
+++ b/src/SigningString.php
@@ -54,8 +54,16 @@ class SigningString
      */
     private function line($name)
     {
-        if ('(request-target)' == $name) {
+        if (preg_match('/^\(.*\)$/', $name)) {
+            switch ($name) {
+            case '(request-target)':
             return $this->requestTargetLine();
+              break;
+
+            default:
+              throw new HeaderException("Special header '$name' not understood", 1);
+              break;
+          }
         } else {
             return sprintf('%s: %s', $name, $this->headerValue($name));
         }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -5,6 +5,7 @@ namespace HttpSignatures\tests;
 use GuzzleHttp\Psr7\Request;
 use HttpSignatures\Context;
 use HttpSignatures\ContextException;
+use HttpSignatures\HeaderException;
 use HttpSignatures\SignatureDatesException;
 use HttpSignatures\Tests\TestKeys;
 use PHPUnit\Framework\TestCase;
@@ -237,6 +238,20 @@ class ContextTest extends TestCase
           '',
           $defaultContext->signer()->getSigningString($this->message)
         );
+        $defaultContext->setHeaders();
+        $this->assertEquals(
+          '(created): '.time(),
+          $defaultContext->signer()->getSigningString($this->message)
+        );
+    }
+
+    public function testRequiredHeaders()
+    {
+        $defaultContext = new Context();
+        $defaultContext->addKeys($this->signingKeySpec);
+        $this->expectException(HeaderException::class);
+        $defaultContext->setHeaders('accept');
+        $signer = $defaultContext->signer();
     }
 
     public function testRejectCreatedInFuture()

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -38,6 +38,26 @@ class ContextTest extends TestCase
         $message = $this->signingContext->signer()->sign($this->message);
     }
 
+    public function testDefaultContext()
+    {
+        $defaultContext = new Context();
+        $defaultContext->addKeys($this->signingKeySpec);
+        $signedMessage = $defaultContext->signer()->sign($this->message);
+        $expectedSignatureLine =
+            'keyId="rsa1",'.
+            'algorithm="hs2019",'.
+            'signature="FM2pgp2riAJ8DYbkkHlxpBAYlsBwn7ItF8NZMhPIHeK3k7fgig4i'.
+            'XZ4WMTrUg97FhzXYOV2mecJz2787vGZ7fmAvhKEyolqZB/TyiTzDWu0WV0+vmEC'.
+            'wGNzfEcoSLLfKEtaG09m3sfSwSkWV/ij4imZmgfbvnxkTM+J9MYQOgqdwyjus6f'.
+            'fSbZmuA8P+3dnm79lost5fpjHbtaTpiIU2T7XZ4xhACy0JrxSBstA9ix52+opdR'.
+            '7PsIUO5r9JwtUFF/r8KObe0TAjCWCAxuolu4ThU5QncHdB5jEtTzTPxR0YYCC/V'.
+            'XE31TLPKkSdcB6RpzBeRTzWjQm5Yk9i3uz2cNw=="';
+        $this->assertEquals(
+            $expectedSignatureLine,
+            $signedMessage->getHeader('Signature')[0]
+        );
+    }
+
     public function testDefaultSigner()
     {
         $this->signingContext->addKeys($this->signingKeySpec);

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -58,7 +58,7 @@ class ContextTest extends TestCase
         );
     }
 
-    public function testv10Signer()
+    public function testv10SigningContext()
     {
         $this->signingContext->addKeys($this->signingKeySpec);
         $signer = $this->signingContext->signer();

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -228,6 +228,17 @@ class ContextTest extends TestCase
           ]);
     }
 
+    public function testEmptyHeaders()
+    {
+        $defaultContext = new Context();
+        $defaultContext->addKeys($this->signingKeySpec);
+        $defaultContext->setHeaders([]);
+        $this->assertEquals(
+          '',
+          $defaultContext->signer()->getSigningString($this->message)
+        );
+    }
+
     public function testRejectCreatedInFuture()
     {
         $defaultContext = new Context();

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -233,27 +233,39 @@ class ContextTest extends TestCase
     {
         $defaultContext = new Context();
         $defaultContext->addKeys($this->signingKeySpec);
-        $defaultContext->setHeaders([]);
-        $this->assertEquals(
-          '',
-          $defaultContext->signer()->getSigningString($this->message)
-        );
         $defaultContext->setHeaders();
         $this->assertEquals(
           '(created): '.time(),
           $defaultContext->signer()->getSigningString($this->message)
         );
+        $defaultContext->setHeaders([]);
+        $defaultContext->setCreated(12345);
+        $this->assertEquals(
+          '',
+          $defaultContext->signer()->getSigningString($this->message)
+        );
     }
 
-    public function testRequiredHeaders()
+    public function testBasicHeaders()
     {
         $defaultContext = new Context();
         $defaultContext->addKeys($this->signingKeySpec);
-        $this->expectException(HeaderException::class);
-        $defaultContext->setHeaders('accept');
-        $signer = $defaultContext->signer();
+        $defaultContext->setHeaders(['date']);
+        $this->assertEquals(
+          'date: today',
+          $defaultContext->signer()->getSigningString($this->message)
+        );
     }
 
+    // public function testRequiredHeaders()
+    // {
+    //     $defaultContext = new Context();
+    //     $defaultContext->addKeys($this->signingKeySpec);
+    //     $this->expectException(HeaderException::class);
+    //     $defaultContext->setHeaders('accept');
+    //     $signer = $defaultContext->signer();
+    // }
+    //
     public function testRejectCreatedInFuture()
     {
         $defaultContext = new Context();

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -38,7 +38,7 @@ class ContextTest extends TestCase
         $message = $this->signingContext->signer()->sign($this->message);
     }
 
-    public function testDefaultContext()
+    public function testDefaultSigningContext()
     {
         $defaultContext = new Context();
         $defaultContext->addKeys($this->signingKeySpec);
@@ -58,7 +58,7 @@ class ContextTest extends TestCase
         );
     }
 
-    public function testDefaultSigner()
+    public function testv10Signer()
     {
         $this->signingContext->addKeys($this->signingKeySpec);
         $signer = $this->signingContext->signer();
@@ -84,6 +84,17 @@ class ContextTest extends TestCase
             $expectedSignatureLine,
             $signedMessage->getHeader('Signature')[0]
         );
+    }
+
+    public function testMismatchedAlgorithms()
+    {
+        $badContext = new Context([
+          'headers' => ['(request-target)', 'date'],
+          'algorithm' => 'dsa-sha256',
+          'keys' => ['mismatched-key' => TestKeys::rsaPrivateKey],
+        ]);
+        $this->expectException(ContextException::class);
+        $badContext->signer()->sign($this->message);
     }
 
     // public function testSha256Signer()

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace HttpSignatures\tests;
+
+use GuzzleHttp\Psr7\Request;
+use HttpSignatures\Context;
+use HttpSignatures\ContextException;
+use HttpSignatures\Tests\TestKeys;
+use PHPUnit\Framework\TestCase;
+
+class ContextTest extends TestCase
+{
+    private $context;
+
+    public function setUp()
+    {
+        $this->signingContext = new Context([
+          'headers' => ['(request-target)', 'date'],
+          'algorithm' => 'rsa-sha256',
+        ]);
+        $this->verifyingContext = new Context();
+        $this->signingKeySpec = ['rsa1' => TestKeys::rsaPrivateKey];
+        // $this->sha256context = new Context([
+        //     'keys' => ['rsa1' => TestKeys::rsaPrivateKey],
+        //     'algorithm' => 'rsa-sha256',
+        //     'headers' => ['(request-target)', 'date'],
+        // ]);
+        $this->message = new Request(
+          'GET',
+          '/path?query=123',
+          ['date' => 'today', 'accept' => 'llamas']
+        );
+    }
+
+    public function testFailSignWithoutKeys()
+    {
+        $this->expectException(ContextException::class);
+        $message = $this->signingContext->signer()->sign($this->message);
+    }
+
+    public function testDefaultSigner()
+    {
+        $this->signingContext->addKeys($this->signingKeySpec);
+        $signer = $this->signingContext->signer();
+        // $this->assertEquals(
+        //   1,
+        //   $this->signingContext->signingKey()
+        // );
+        $signedMessage = $signer->sign($this->message);
+
+        $expectedSignatureLine = implode(',', [
+            'keyId="rsa1"',
+            'algorithm="rsa-sha256"',
+            'headers="(request-target) date"',
+            'signature="WGIegQCC3GEwxbkuXtq67CAqeDhkwblxAH2uoDx5kfWurhLRA5WB'.
+            'FDA/aktsZAjuUoimG1w4CGxSecziER1ez44PBlHP2fCW4ArLgnQgcjkdN2cOf/g'.
+            'j0OVL8s2usG4o4tud/+jjF3nxTxLl3HC+erBKsJakwXbw9kt4Cr028BToVfNXsW'.
+            'oMFpv0IjcgBH2V41AVlX/mYBMMJAihBCIcpgAcGrrxmG2gkfvSn09wtTttkGHft'.
+            'PIp3VpB53zbemlJS9Yw3tmmHr6cvWSXqQy/bTsEOoQJ2REfn5eiyzsJu3GiOpiI'.
+            'LK67i/WH9moltJtlfV57TV72cgYtjWa6yqhtFg=="',
+        ]);
+
+        $this->assertEquals(
+            $expectedSignatureLine,
+            $signedMessage->getHeader('Signature')[0]
+        );
+    }
+
+    // public function testSha256Signer()
+    // {
+    //     $expectedDigestHeader = 'SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
+    //
+    //     $signedMessage = $this->sha256context->signer()->sign($this->message);
+    //     $expectedSha256String = implode(',', [
+    //         'keyId="rsa1"',
+    //         'algorithm="rsa-sha256"',
+    //         'headers="(request-target) date"',
+    //         'signature="WGIegQCC3GEwxbkuXtq67CAqeDhkwblxAH2uoDx5kfWurhLRA5WB'.
+    //         'FDA/aktsZAjuUoimG1w4CGxSecziER1ez44PBlHP2fCW4ArLgnQgcjkdN2cOf/g'.
+    //         'j0OVL8s2usG4o4tud/+jjF3nxTxLl3HC+erBKsJakwXbw9kt4Cr028BToVfNXsW'.
+    //         'oMFpv0IjcgBH2V41AVlX/mYBMMJAihBCIcpgAcGrrxmG2gkfvSn09wtTttkGHft'.
+    //         'PIp3VpB53zbemlJS9Yw3tmmHr6cvWSXqQy/bTsEOoQJ2REfn5eiyzsJu3GiOpiI'.
+    //         'LK67i/WH9moltJtlfV57TV72cgYtjWa6yqhtFg=="',
+    //     ]);
+    //
+    //     $this->assertEquals(
+    //         $expectedSha256String,
+    //         $signedMessage->getHeader('Signature')[0]
+    //     );
+    //
+    //     $signedWithDigestMessage = $this->sha256context->signer()->signWithDigest($this->message);
+    //
+    //     $this->assertEquals(
+    //         $expectedDigestHeader,
+    //         $signedWithDigestMessage->getHeader('Digest')[0]
+    //     );
+    //
+    //     $authorizedWithDigestMessage = $this->sha256context->signer()->authorizeWithDigest($this->message);
+    //
+    //     $this->assertEquals(
+    //         $expectedDigestHeader,
+    //         $authorizedWithDigestMessage->getHeader('Digest')[0]
+    //     );
+    // }
+    //
+    // public function testGetSigningString()
+    // {
+    //     $this->assertEquals(
+    //       "(request-target): get /path?query=123\ndate: today",
+    //       $this->sha256context->signer()->getSigningString($this->message)
+    //     );
+    // }
+    //
+    // public function testRsaBadalgorithm()
+    // {
+    //     $this->expectException(\HTTPSignatures\AlgorithmException::class);
+    //     $sha224context = new Context([
+    //           'keys' => ['rsa1' => TestKeys::rsaPrivateKey],
+    //           'algorithm' => 'rsa-sha224',
+    //           'headers' => ['(request-target)', 'date'],
+    //       ]);
+    // }
+    //
+    // public function testEmptyHeaders()
+    // {
+    //     $emptyHeadersContext = new Context([
+    //         'keys' => ['rsa1' => TestKeys::rsaPrivateKey],
+    //         'algorithm' => 'rsa-sha256',
+    //         'headers' => [],
+    //     ]);
+    //
+    //     $signedMessage = $emptyHeadersContext->signer()->sign($this->message);
+    //     $this->assertEquals(
+    //       'keyId="rsa1",algorithm="rsa-sha256",signature="Mutm6x0apXqU6aQh36l'.
+    //       '+/yEU0kSzKt8tEy6nxhBXJIv0kP+z9MWH0k7CgsLLt4RcGmf5i6qnmPkkKZ5ndLUL'.
+    //       'FnXpFIQjs2aWaQ4Twq29no/acrkJA1S9zFJEIy9uI+UJurzlpWe3pTBdyAvF0PnMC'.
+    //       '4IQJ0f7QRyWjMCSmHGKEv7iZGmt9l1l1zbx7DHeuaLCj1AIZlwhvw0bg+uk7NrgFG'.
+    //       '2Vix1w707O/u8K3IrHFDDpbNBI2YmqklyAuoPtVe+DFlaC/G80ew3VyNU9lqNAQxL'.
+    //       'eD0/O05xNNdJ7xjaaAPdv0VXYwzC70aek1ZY1RKlSmDi6x5k/clmtcWsqNx1RJw=="',
+    //       $signedMessage->getHeader('Signature')[0]
+    //     );
+    // }
+
+    public function testBadHashAlgorithm()
+    {
+        $this->expectException(\HttpSignatures\AlgorithmException::class);
+        $sha224context = new Context([
+              'keys' => ['rsa1' => TestKeys::rsaPrivateKey],
+              'algorithm' => 'rsa-sha224',
+              'headers' => ['(request-target)', 'date'],
+          ]);
+    }
+}

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -42,16 +42,65 @@ class ContextTest extends TestCase
     {
         $defaultContext = new Context();
         $defaultContext->addKeys($this->signingKeySpec);
+        $defaultContext->setCreated(1566239000);
+        $dates = $defaultContext->signatureDates();
+        $this->assertEquals(
+          [1566239000, null],
+          [$dates->getCreated(), $dates->getExpires()]
+        );
+        $signer = $defaultContext->signer();
+        $this->assertEquals(
+            implode("\n", [
+              '(created): 1566239000',
+            ]),
+            $signer->getSigningString($this->message)
+        );
         $signedMessage = $defaultContext->signer()->sign($this->message);
         $expectedSignatureLine =
             'keyId="rsa1",'.
             'algorithm="hs2019",'.
-            'signature="FM2pgp2riAJ8DYbkkHlxpBAYlsBwn7ItF8NZMhPIHeK3k7fgig4i'.
-            'XZ4WMTrUg97FhzXYOV2mecJz2787vGZ7fmAvhKEyolqZB/TyiTzDWu0WV0+vmEC'.
-            'wGNzfEcoSLLfKEtaG09m3sfSwSkWV/ij4imZmgfbvnxkTM+J9MYQOgqdwyjus6f'.
-            'fSbZmuA8P+3dnm79lost5fpjHbtaTpiIU2T7XZ4xhACy0JrxSBstA9ix52+opdR'.
-            '7PsIUO5r9JwtUFF/r8KObe0TAjCWCAxuolu4ThU5QncHdB5jEtTzTPxR0YYCC/V'.
-            'XE31TLPKkSdcB6RpzBeRTzWjQm5Yk9i3uz2cNw=="';
+            'created=1566239000,'.
+            'signature="Me94a2KUd1+9X8sAFqkHWn8Ze/hz4kREoCbqKn03BTwXd9gcVKMGp6'.
+            'XfpdXalktOTlcNyli0dQlw9kNtU9VeJ1N8/nSj2TY96wQW6p397m6CdYCGJmAqZpf'.
+            '/CzqJFJslp6i7iRB2GJMzbYbCsTVK/oEPlxMB0rMYxosVB2qwaLNsbqobo1FF9L1d'.
+            'I0JE+M2l3Eil9K2Z/TMItRjIlii0a4l3qauxJ8fDOu5uo5mFywrm3oiWrihBBJvI+'.
+            'n4cYmBc+gxByrDDYbH2n2gdKFykHkROdU/N4ic/nV7qycJxLCoWSyZpZp73ilYs4U'.
+            'TZkh9B32LHJNAo/5D7YrKJXmX3NQ=="';
+        $this->assertEquals(
+            $expectedSignatureLine,
+            $signedMessage->getHeader('Signature')[0]
+        );
+        $defaultContext->setExpires('+300');
+        $defaultContext->setExpires('+300');
+        $dates = $defaultContext->signatureDates();
+        $this->assertEquals(
+          [1566239000, 1566239300],
+          [$dates->getCreated(), $dates->getExpires()]
+        );
+        $defaultContext->setHeaders([
+          '(request-target)', '(created)', '(expires)', ]);
+        $signer = $defaultContext->signer();
+        $signedMessage = $signer->sign($this->message);
+        $this->assertEquals(
+            implode("\n", [
+              '(request-target): get /path?query=123',
+              '(created): 1566239000',
+              '(expires): 1566239300',
+            ]),
+            $signer->getSigningString($this->message)
+        );
+        $expectedSignatureLine =
+            'keyId="rsa1",'.
+            'algorithm="hs2019",'.
+            'created=1566239000,'.
+            'expires=1566239300,'.
+            'headers="(request-target) (created) (expires)",'.
+            'signature="Hav9yNOVldI9QzIRUCCP6PeGQ2ji/CtlZ5TWX0VVQ72ZMnch5hpvfj'.
+            '53lDIg9sy14E7FazajttkX/OejwRGhHmlO/x9NGi/2aap8AuBIHXK+7jeP/rXxhf+'.
+            'X2yrsF9Ihp/4DSbsketJinnH16Unrd7BknqTByDvgGIC7bCPeP/dCsAw7taIoVBaF'.
+            'heO7HL1gPADjIjHeD/aZadsITM+HPc+rlNpgeAE3+3OzjUnUtT81LN0aqZHZJEmXh'.
+            'BTHFm1vB2oGm5B/yayZ8KyUbc1z6iVsgAQestu4Y7wSivAnjooFolYKeJeYn6h1hx'.
+            '5qbFVGQ6WF8V8cqrkbSzSfWyUhmg=="';
         $this->assertEquals(
             $expectedSignatureLine,
             $signedMessage->getHeader('Signature')[0]
@@ -62,10 +111,6 @@ class ContextTest extends TestCase
     {
         $this->signingContext->addKeys($this->signingKeySpec);
         $signer = $this->signingContext->signer();
-        // $this->assertEquals(
-        //   1,
-        //   $this->signingContext->signingKey()
-        // );
         $signedMessage = $signer->sign($this->message);
 
         $expectedSignatureLine = implode(',', [

--- a/tests/HeaderListTest.php
+++ b/tests/HeaderListTest.php
@@ -13,6 +13,14 @@ class HeaderListTest extends TestCase
         $this->assertEquals('(request-target) date', $hl->string());
     }
 
+    public function testEmpty()
+    {
+        $hl = HeaderList::fromString('');
+        $this->assertEquals('', $hl->string());
+        $hl = new HeaderList([]);
+        $this->assertEquals('', $hl->string());
+    }
+
     public function testFromStringRoundTripNormalized()
     {
         $hl = HeaderList::fromString('(request-target) Accept');

--- a/tests/HeaderListTest.php
+++ b/tests/HeaderListTest.php
@@ -18,4 +18,10 @@ class HeaderListTest extends TestCase
         $hl = HeaderList::fromString('(request-target) Accept');
         $this->assertEquals('(request-target) accept', $hl->string());
     }
+
+    public function testList()
+    {
+        $hl = HeaderList::fromString('(request-target) Accept');
+        $this->assertEquals(['(request-target)', 'accept'], $hl->list());
+    }
 }

--- a/tests/HeaderListTest.php
+++ b/tests/HeaderListTest.php
@@ -22,6 +22,6 @@ class HeaderListTest extends TestCase
     public function testList()
     {
         $hl = HeaderList::fromString('(request-target) Accept');
-        $this->assertEquals(['(request-target)', 'accept'], $hl->list());
+        $this->assertEquals(['(request-target)', 'accept'], $hl->listHeaders());
     }
 }

--- a/tests/HmacContextTest.php
+++ b/tests/HmacContextTest.php
@@ -297,13 +297,17 @@ class HmacContextTest extends TestCase
         $algorithmsContext = new Context([
             'keys' => ['pda' => 'secret'],
             'algorithm' => 'hs2019',
-            'headers' => ['(request-target)', 'date'],
+            'headers' => ['(request-target)', '(created)'],
         ]);
+        $algorithmsContext->setCreated(1566254000);
         $signatureLine = $algorithmsContext->signer()->sign($message)->getHeader('Signature')[0];
         $this->assertEquals(
-          'keyId="pda",algorithm="hs2019",headers="(request-target) date",'.
-          'signature="0mFj7Fau0KQQIfSnPm651QEDlPpi40SaAt8TmowgpUFuavp3RQ2dXqHO'.
-          'iZLcDTt7H84ZLfJty4lbtEEb64Sfxg=="',
+          'keyId="pda",'.
+          'algorithm="hs2019",'.
+          'created=1566254000,'.
+          'headers="(request-target) (created)",'.
+          'signature="g9QBrm67MkUaYwESkfqsXtmWnvrFWI723TLgQ6CuKFu+7mzP62xYQob'.
+          'PTyttOoAhhR/AvufL9AlFJViMGhDGmg=="',
           $signatureLine
         );
     }

--- a/tests/HmacContextTest.php
+++ b/tests/HmacContextTest.php
@@ -241,4 +241,70 @@ class HmacContextTest extends TestCase
             $message->getHeader('Signature')[0]
         );
     }
+
+    public function testSignHashAlgorithms()
+    {
+        $message = new Request(
+          'GET', '/path?query=123',
+          ['date' => 'today', 'accept' => 'llamas']
+        );
+        $algorithmsContext = new Context([
+            'keys' => ['pda' => 'secret'],
+            'algorithm' => 'hmac-sha1',
+            'headers' => ['(request-target)', 'date'],
+        ]);
+        $signatureLine = $algorithmsContext->signer()->sign($message)->getHeader('Signature')[0];
+        $this->assertEquals(
+          'keyId="pda",algorithm="hmac-sha1",headers="(request-target) date",'.
+          'signature="LhHzf9kLUSTzQXqApn6PEfcemck="',
+          $signatureLine
+        );
+        $algorithmsContext = new Context([
+            'keys' => ['pda' => 'secret'],
+            'algorithm' => 'hmac-sha256',
+            'headers' => ['(request-target)', 'date'],
+        ]);
+        $signatureLine = $algorithmsContext->signer()->sign($message)->getHeader('Signature')[0];
+        $this->assertEquals(
+          'keyId="pda",algorithm="hmac-sha256",headers="(request-target) date",'.
+          'signature="SFlytCGpsqb/9qYaKCQklGDvwgmrwfIERFnwt+yqPJw="',
+          $signatureLine
+        );
+        $algorithmsContext = new Context([
+            'keys' => ['pda' => 'secret'],
+            'algorithm' => 'hmac-sha384',
+            'headers' => ['(request-target)', 'date'],
+        ]);
+        $signatureLine = $algorithmsContext->signer()->sign($message)->getHeader('Signature')[0];
+        $this->assertEquals(
+          'keyId="pda",algorithm="hmac-sha384",headers="(request-target) date",'.
+          'signature="xzcM2jy8EPGSoOqWlCGrYp/BmB5k0aoOfIIH3RzIA+Btl3e3bgIn4VrEE'.
+          'udw36Ij"',
+          $signatureLine
+        );
+        $algorithmsContext = new Context([
+            'keys' => ['pda' => 'secret'],
+            'algorithm' => 'hmac-sha512',
+            'headers' => ['(request-target)', 'date'],
+        ]);
+        $signatureLine = $algorithmsContext->signer()->sign($message)->getHeader('Signature')[0];
+        $this->assertEquals(
+          'keyId="pda",algorithm="hmac-sha512",headers="(request-target) date",'.
+          'signature="0mFj7Fau0KQQIfSnPm651QEDlPpi40SaAt8TmowgpUFuavp3RQ2dXqHOi'.
+          'ZLcDTt7H84ZLfJty4lbtEEb64Sfxg=="',
+          $signatureLine
+        );
+        $algorithmsContext = new Context([
+            'keys' => ['pda' => 'secret'],
+            'algorithm' => 'hs2019',
+            'headers' => ['(request-target)', 'date'],
+        ]);
+        $signatureLine = $algorithmsContext->signer()->sign($message)->getHeader('Signature')[0];
+        $this->assertEquals(
+          'keyId="pda",algorithm="hs2019",headers="(request-target) date",'.
+          'signature="0mFj7Fau0KQQIfSnPm651QEDlPpi40SaAt8TmowgpUFuavp3RQ2dXqHO'.
+          'iZLcDTt7H84ZLfJty4lbtEEb64Sfxg=="',
+          $signatureLine
+        );
+    }
 }

--- a/tests/KeyStoreTest.php
+++ b/tests/KeyStoreTest.php
@@ -3,6 +3,7 @@
 namespace HttpSignatures\tests;
 
 use HttpSignatures\KeyStore;
+use HttpSignatures\KeyStoreException;
 use PHPUnit\Framework\TestCase;
 
 class KeyStoreTest extends TestCase
@@ -28,6 +29,7 @@ class KeyStoreTest extends TestCase
           'secret-key',
           $this->ks->fetch('another')->getSigningKey()
         );
+        $this->expectException(KeyStoreException::class);
         $this->ks->addKeys(['another' => 'duplicate']);
     }
 

--- a/tests/KeyStoreTest.php
+++ b/tests/KeyStoreTest.php
@@ -7,10 +7,41 @@ use PHPUnit\Framework\TestCase;
 
 class KeyStoreTest extends TestCase
 {
+    public function setUp()
+    {
+        $this->ks = new KeyStore(['first' => 'secret']);
+    }
+
+    public function testCreatedandAdd()
+    {
+        $this->assertEquals(
+          1,
+          $this->ks->count()
+        );
+        $ks = $this->ks;
+        $this->ks->addKeys(['another' => 'secret-key']);
+        $this->assertEquals(
+          2,
+          $this->ks->count()
+        );
+        $this->assertEquals(
+          'secret-key',
+          $this->ks->fetch('another')->getSigningKey()
+        );
+        $this->ks->addKeys(['another' => 'duplicate']);
+    }
+
+    public function testFetch()
+    {
+        $this->assertEquals(
+        'secret',
+        $this->ks->fetch('first')->getSigningKey()
+      );
+    }
+
     public function testFetchFail()
     {
-        $ks = new KeyStore(['id' => 'secret']);
         $this->expectException(\HttpSignatures\KeyStoreException::class);
-        $key = $ks->fetch('nope');
+        $key = $this->ks->fetch('nope');
     }
 }

--- a/tests/RsaContextTest.php
+++ b/tests/RsaContextTest.php
@@ -92,16 +92,6 @@ class RsaContextTest extends TestCase
         );
     }
 
-    public function testRsaBadalgorithm()
-    {
-        $this->expectException(\HTTPSignatures\AlgorithmException::class);
-        $sha224context = new Context([
-              'keys' => ['rsa1' => TestKeys::rsaPrivateKey],
-              'algorithm' => 'rsa-sha224',
-              'headers' => ['(request-target)', 'date'],
-          ]);
-    }
-
     public function testEmptyHeaders()
     {
         $emptyHeadersContext = new Context([

--- a/tests/SignatureDatesTest.php
+++ b/tests/SignatureDatesTest.php
@@ -106,6 +106,14 @@ class SignatureDatesTest extends TestCase
           SignatureDates::Offset('-45')
         );
         $this->assertEquals(
+          1566139030,
+          SignatureDates::Offset('+30', 1566139000)
+        );
+        $this->assertEquals(
+          1566138955,
+          SignatureDates::Offset('-45', 1566139000)
+        );
+        $this->assertEquals(
           1566139000,
           SignatureDates::Offset(1566139000)
         );

--- a/tests/SignatureDatesTest.php
+++ b/tests/SignatureDatesTest.php
@@ -86,4 +86,28 @@ class SignatureDatesTest extends TestCase
           $signatureDates->toExpire() <= 20
         );
     }
+
+    public function testOffset()
+    {
+        $this->assertEquals(
+          time(),
+          SignatureDates::Offset('now')
+        );
+        $this->assertEquals(
+          null,
+          SignatureDates::Offset('none')
+        );
+        $this->assertEquals(
+          time() + 30,
+          SignatureDates::Offset('+30')
+        );
+        $this->assertEquals(
+          time() - 45,
+          SignatureDates::Offset('-45')
+        );
+        $this->assertEquals(
+          1566139000,
+          SignatureDates::Offset(1566139000)
+        );
+    }
 }

--- a/tests/SignatureDatesTest.php
+++ b/tests/SignatureDatesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace HttpSignatures\tests;
+
+use PHPUnit\Framework\TestCase;
+use HttpSignatures\SignatureDates;
+
+class SignatureDatesTest extends TestCase
+{
+    public function testCreated()
+    {
+        $signatureDates = new SignatureDates();
+        $this->assertTrue(
+          $signatureDates->hasStarted()
+        );
+        $this->assertEquals(
+          null,
+          $signatureDates->sinceCreated()
+        );
+        $this->assertTrue(
+          $signatureDates->hasStarted(time() + 5)
+        );
+        $this->assertTrue(
+          $signatureDates->hasStarted(time() - 5)
+        );
+        $signatureDates = new SignatureDates();
+        $signatureDates->setCreated(time() + 2);
+        $this->assertFalse(
+          $signatureDates->hasStarted()
+        );
+        $signatureDates->setCreated(time() - 20);
+        $this->assertTrue(
+          $signatureDates->hasStarted()
+        );
+        $this->assertTrue(
+          $signatureDates->sinceCreated() <= 20
+        );
+        $signatureDates = new SignatureDates();
+        $signatureDates->setCreated(time() + 2);
+        $this->assertFalse(
+          $signatureDates->hasStarted()
+        );
+        $signatureDates->setCreatedDrift(5);
+        $this->assertTrue(
+          $signatureDates->hasStarted()
+        );
+        $signatureDates = new SignatureDates(1);
+        $this->assertTrue(
+          $signatureDates->hasStarted()
+        );
+    }
+
+    public function testExpires()
+    {
+        $signatureDates = new SignatureDates();
+        $this->assertFalse(
+          $signatureDates->hasExpired()
+        );
+        $signatureDates->setExpires(time() - 2);
+        $this->assertFalse(
+          $signatureDates->hasExpired(time() - 5)
+        );
+        $this->assertTrue(
+          $signatureDates->hasExpired(time() + 5)
+        );
+        $signatureDates = new SignatureDates();
+        $signatureDates->setExpires(time() - 2);
+        $this->assertTrue(
+          $signatureDates->hasExpired()
+        );
+        $signatureDates->setExpiresDrift(5);
+        $this->assertFalse(
+          $signatureDates->hasExpired()
+        );
+        $signatureDates->setExpiresDrift(0);
+        $this->assertTrue(
+          $signatureDates->hasExpired()
+        );
+        $signatureDates = new SignatureDates();
+        $this->assertEquals(
+          null,
+          $signatureDates->toExpire()
+        );
+        $signatureDates->setExpires(time() + 20);
+        $this->assertTrue(
+          $signatureDates->toExpire() <= 20
+        );
+    }
+}


### PR DESCRIPTION
Support v11-compliant signing, including:

- New 'hs2019' ``algorithm`` value
- Support SHA-512 (which is what hs2019 expects under the hood)
- Mask real key algorithm names when new ``algorithm`` names are used
- More explicit error types
- Allow contextless creation of Contexts:
    - add keys later (better support for default ``algorithm``)
    - set ``headers`` later