### PR TITLE
fix(body-digest): fix the digest may be duplicated when it is at index 0

### DIFF
--- a/src/BodyDigest.php
+++ b/src/BodyDigest.php
@@ -51,7 +51,7 @@ class BodyDigest
 
     public function putDigestInHeaderList($headerList)
     {
-        if (array_search('digest', $headerList->names) === false) {
+        if (false === array_search('digest', $headerList->names)) {
             $headerList->names[] = 'digest';
         }
 

--- a/src/BodyDigest.php
+++ b/src/BodyDigest.php
@@ -51,7 +51,7 @@ class BodyDigest
 
     public function putDigestInHeaderList($headerList)
     {
-        if (!array_search('digest', $headerList->names)) {
+        if (array_search('digest', $headerList->names) === false) {
             $headerList->names[] = 'digest';
         }
 


### PR DESCRIPTION
When the `digest` is at index 0, `array_search()` will return 0 but the **if** statement will become `!0`, which indicates the `digest` is not found in the `$headerList` and the program appends it to the array.

Before
```
[
  0 => "digest"
  1 => "(request-target)"
]
```

After
```
[
  0 => "digest"
  1 => "(request-target)"
  2 => "digest"
]
```

This change will improve the checking and only append `digest` when `array_search()` returns `false`.

EDIT: Added the missing 'if' before 'statement'